### PR TITLE
C/C++ MVG metric return patch

### DIFF
--- a/cccc/cccc.g
+++ b/cccc/cccc.g
@@ -202,7 +202,7 @@ inline void endOfLine(CLexer &lexer)
 #token PROTECTED "protected" << ; >>
 #token PUBLIC "public" << ; >>
 #token REGISTER "register" << ; >>
-#token RETURN "return" << IncrementCount(tcMCCABES_VG); >>
+#token RETURN "return" << ; >>
 #token KW_SHORT "short" << ; >>
 #token SIGNED "signed" << ; >>
 #token SIZEOF "sizeof" << ; >>

--- a/cccc/cccc_utl.cc
+++ b/cccc/cccc_utl.cc
@@ -299,6 +299,8 @@ insert_extent(CCCC_Item& os, int startLine, int endLine,
     {
       lexical_counts_for_this_extent[i]=0;
     }
+  // Patch for starting the McCabe MVG metric with at least 1.
+  lexical_counts_for_this_extent[tcMCCABES_VG] = 1;
 
   if(allocate_lexcounts==true)
     {


### PR DESCRIPTION
I added a small patch to the *cccc.g* and *cccc_utl.cc*. In case a `return` statement is encountered during lexing the C/C++ files the MVG metric will not be incremented. The MVG also now starts at a default value
of 1 instead of 0. 

The test databases remain unchanged at the moment. 