### PR TITLE
Add dependency on PCCTS-generated files for compiling ccccmain

### DIFF
--- a/cccc/rules.mak
+++ b/cccc/rules.mak
@@ -115,6 +115,7 @@ JAVA_LANG_DEFINE=-DJAVA_INCLUDED
 #ADA_SPAWN_OBJ=ada.$(OBJEXT) ALexer.$(OBJEXT) AdaPrser.$(OBJEXT)
 #ADA_LANG_DEFINE=-DADA_INCLUDED
 
+SPAWN = $(CCCC_SPAWN) $(JAVA_SPAWN) # $(ADA_SPAWN)
 SPAWN_OBJ = $(CCCC_SPAWN_OBJ) $(JAVA_SPAWN_OBJ) $(ADA_SPAWN_OBJ)
 LANG_DEFINES = $(CC_LANG_DEFINE) $(JAVA_LANG_DEFINE) $(ADA_LANG_DEFINE)
 
@@ -148,7 +149,7 @@ $(CCCC_EXE): $(USR_G) $(ANLTR_SPAWN) $(DLG_SPAWN) $(USR_H) $(USR_C) $(ALL_OBJ)
 	$(ANTLR) $(AFLAGS) -gc -gx -pa $< > $*.1st
 	$(ANTLR) $(AFLAGS) -gc -gx -cr $< > $*.xrf
 
-ccccmain.$(OBJEXT) : ccccmain.cc 
+ccccmain.$(OBJEXT) : ccccmain.cc $(SPAWN)
 	$(CCC) $(CCC_OPTS) $(LANG_DEFINES) ccccmain.cc
 
 


### PR DESCRIPTION
The missing dependency was sometimes (on the order of one in four times on my system) visible when using `make --shuffle` from GNU Make 4.4, resulting in something like this:

```
ccccmain.cc:33:10: fatal error: CParser.h: No such file or directory
   33 | #include "CParser.h"
      |          ^~~~~~~~~~~
compilation terminated.
```

It's a bit awkward to handle the way that generating the Ada files is disabled, but I tried to roughly match the way that `ADA_SPAWN_OBJ` and `ADA_LANG_DEFINE` are commented out.